### PR TITLE
Don't break sysimages

### DIFF
--- a/src/sky130_fd_pr.jl
+++ b/src/sky130_fd_pr.jl
@@ -1,5 +1,5 @@
 module sky130_fd_pr
 	# ERROR: TODO: Maybe have a julia-side SPICE model registry also,
 	# to avoid requiring explicit .lib in the `.sp` files?
-	__init__() = error("This is a SPICE model package, not a julia package. Don't attempt to load it like this.")
+	# __init__() = error("This is a SPICE model package, not a julia package. Don't attempt to load it like this.")
 end


### PR DESCRIPTION
This init step errors when starting julia with a sysimage that includes this package.